### PR TITLE
Use a block to specify rails assets gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
-source "https://rails-assets.org"
 
 # Heroku uses the ruby version to configure your application's runtime.
 ruby "2.0.0"
@@ -45,9 +44,11 @@ gem "turbolinks"
 gem "uglifier", ">= 1.3.0"
 
 # Rails assets
-gem "rails-assets-jquery"
-gem "rails-assets-jquery-ujs-standalone"
-gem "rails-assets-viewloader"
+source "https://rails-assets.org" do
+  gem "rails-assets-jquery"
+  gem "rails-assets-jquery-ujs-standalone"
+  gem "rails-assets-viewloader"
+end
 
 group :production do
   gem "rails_12factor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,9 +399,9 @@ DEPENDENCIES
   quiet_assets
   rack-canonical-host
   rails (~> 4.1.0)
-  rails-assets-jquery
-  rails-assets-jquery-ujs-standalone
-  rails-assets-viewloader
+  rails-assets-jquery!
+  rails-assets-jquery-ujs-standalone!
+  rails-assets-viewloader!
   rails_12factor
   rb-fsevent
   react-rails!


### PR DESCRIPTION
Bundler reports that using multiple sources in a Gemfile is a security risk. This silences that warning.