### PR TITLE
Add RSpec examples that fail if db:seed or db:sample_data raise an error

### DIFF
--- a/spec/sample_data_spec.rb
+++ b/spec/sample_data_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'db:sample_data' do
+  include_context 'rake'
+
+  it 'seeds the database with sample_data - `rake db:sample_data`' do
+    expect { subject.invoke }.to_not raise_error
+  end
+end
+
+RSpec.describe 'db:seed' do
+
+  it 'seeds the database with seed data - `rake db:seed`' do
+    expect { Rails.application.load_seed }.to_not raise_error
+  end
+end

--- a/spec/sample_data_spec.rb
+++ b/spec/sample_data_spec.rb
@@ -4,12 +4,11 @@ RSpec.describe 'db:sample_data' do
   include_context 'rake'
 
   it 'seeds the database with sample_data - `rake db:sample_data`' do
-    expect { subject.invoke }.to_not raise_error
+    expect { task.invoke }.to_not raise_error
   end
 end
 
 RSpec.describe 'db:seed' do
-
   it 'seeds the database with seed data - `rake db:seed`' do
     expect { Rails.application.load_seed }.to_not raise_error
   end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,19 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -4,7 +4,7 @@ shared_context "rake" do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
-  subject         { rake[task_name] }
+  subject(:task)         { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
     $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,13 +1,13 @@
-require "rake"
+require 'rake'
 
-shared_context "rake" do
+shared_context 'rake' do
   let(:rake)      { Rake::Application.new }
   let(:task_name) { self.class.top_level_description }
   let(:task_path) { "lib/tasks/#{task_name.split(":").first}" }
-  subject(:task)         { rake[task_name] }
+  subject(:task)  { rake[task_name] }
 
   def loaded_files_excluding_current_rake_file
-    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+    $".reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
   end
 
   before do


### PR DESCRIPTION
#20 : Added 2 examples that will fail if an exception is raised. There may be more scenarios that this could cover, but an outright failure due to an issue with the data or database (syntax error or no method error) seems to be most common.

Would be nice if they could be ignored when running Guard, might look into that next.